### PR TITLE
feat(report): add report list by urls

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a11ywatch_cli"
-version = "0.6.23"
+version = "0.6.24"
 authors = ["j-mendez <jeff@a11ywatch.com>"]
 description = "A11yWatch accessibility CLI."
 repository = "https://github.com/a11ywatch/a11ywatch"

--- a/cli/src/formatters/mod.rs
+++ b/cli/src/formatters/mod.rs
@@ -2,5 +2,5 @@ pub mod body;
 
 pub(crate) use self::body::{
     format_body, results_issues_count, results_issues_errors_count, results_issues_warnings_count,
-    results_to_string, results_to_string_github,
+    results_to_string, results_to_string_github, get_report_url_errors
 };

--- a/cli/src/fs/temp.rs
+++ b/cli/src/fs/temp.rs
@@ -108,10 +108,12 @@ impl TempFs {
 
     /// read results from scan to string
     pub fn read_results(&self) -> String {
-        let mut file = File::open(&self.results_file).unwrap();
         let mut data = String::new();
-        file.read_to_string(&mut data).unwrap();
-
+        if Path::new(&self.results_file).exists() {
+            let mut file = File::open(&self.results_file).unwrap();
+            file.read_to_string(&mut data).unwrap();
+        }
+        
         data
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,7 @@ pub mod utils;
 
 use self::formatters::{
     format_body, results_issues_count, results_issues_errors_count, results_issues_warnings_count,
-    results_to_string, results_to_string_github,
+    results_to_string, results_to_string_github, get_report_url_errors
 };
 use crate::utils::Issue;
 use clap::Parser;
@@ -70,6 +70,10 @@ fn main() {
 
     if cli.results_parsed_github {
         println!("{}", results_to_string_github(&file_manager));
+    }
+
+    if cli.results_parsed_list {
+        println!("{}", get_report_url_errors(&file_manager));
     }
 
     if cli.results_issues {

--- a/cli/src/options/args.rs
+++ b/cli/src/options/args.rs
@@ -32,6 +32,9 @@ pub struct Cli {
     /// Get results of the github html message
     #[clap(long)]
     pub results_parsed_github: bool,
+    /// Get results file parsed as report list of passed and failed
+    #[clap(short, long)]
+    pub results_parsed_list: bool,
     /// Get the total amount of issues between errors,warning,notice that occured for the result set.
     #[clap(long)]
     pub results_issues: bool,


### PR DESCRIPTION
* add url report list output across pages


ex:

Make sure to use the `--save` command to store the prev report.

```sh
a11ywatch crawl -u https://jeffmendez.com --save
a11ywatch --results-parsed-list 
```
![Ran A11yWatch on 3 URLs: jeffmendez.com - 0 errors jeffmendez.com/about - 0 errors jeffmendez.com/tags - 1 error x 2/3 URLs passed](https://user-images.githubusercontent.com/8095978/182402172-7b462c92-bdcd-443c-ad10-ac29659c8650.png)
