### PR TITLE
extract error and warnings correctly from results json

### DIFF
--- a/cli/src/formatters/body.rs
+++ b/cli/src/formatters/body.rs
@@ -81,9 +81,9 @@ pub(crate) fn extract_issues_count(file_manager: &TempFs) -> (usize, usize, usiz
         let pages = data.as_array().unwrap();
 
         for page in pages {
-            let errors = &page["issues_info"]["warning_count"];
+            let errors = &page["issuesInfo"]["errorCount"];
             let errors: usize = format!("{}", errors).parse().unwrap_or_default();
-            let warnings = &page["issues_info"]["warning_count"];
+            let warnings = &page["issuesInfo"]["warningCount"];
             let warnings: usize = format!("{}", warnings).parse().unwrap_or_default();
 
             error_count += errors;
@@ -92,9 +92,9 @@ pub(crate) fn extract_issues_count(file_manager: &TempFs) -> (usize, usize, usiz
     }
 
     if data.is_object() {
-        let errors = &data["issues_info"]["warning_count"];
+        let errors = &data["issuesInfo"]["errorCount"];
         let errors: usize = format!("{}", errors).parse().unwrap_or_default();
-        let warnings = &data["issues_info"]["warning_count"];
+        let warnings = &data["issuesInfo"]["warningCount"];
         let warnings: usize = format!("{}", warnings).parse().unwrap_or_default();
 
         error_count += errors;
@@ -120,7 +120,7 @@ pub(crate) fn get_report_url_errors(file_manager: &TempFs) -> String {
         url_count = pages.len();
 
         for page in pages {
-            let errors = &page["issues_info"]["error_count"];
+            let errors = &page["issuesInfo"]["errorCount"];
             let errors: usize = format!("{}", errors).parse().unwrap_or_default();
 
             let s = if errors == 1 { "" } else { "s" };
@@ -133,6 +133,21 @@ pub(crate) fn get_report_url_errors(file_manager: &TempFs) -> String {
             if errors == 0 {
                 pages_passed += 1;
             }
+        }
+    } else if data.is_object() {
+        url_count = 1;
+        let errors = &data["issuesInfo"]["errorCount"];
+        let errors: usize = format!("{}", errors).parse().unwrap_or_default();
+
+        let s = if errors == 1 { "" } else { "s" };
+        url_list.push_str(&format!(
+            " > {} - {} error{s}\n",
+            &data["url"].as_str().unwrap_or_default(),
+            &errors
+        ));
+
+        if errors == 0 {
+            pages_passed += 1;
         }
     }
 


### PR DESCRIPTION
No errors/warnings were being reported in CI, did some digging and it seems like the JSON keys are camel case, whereas the code was expecting snake case. This PR changes to using camel case. Also the `--results-parsed-list` didn't work with the output of a scan (only crawls) so I have also fixed that. Now running things like `a11ywatch -r` and `a11ywatch --results-issues` reports the errors correctly.